### PR TITLE
Add windows compatibility

### DIFF
--- a/lib/push_package.rb
+++ b/lib/push_package.rb
@@ -27,7 +27,7 @@ class PushPackage
       cert_data = certificate.read
       certificate.rewind if certificate.respond_to?(:rewind)
     else
-      cert_data = File.read(certificate)
+      cert_data = File.binread(certificate)
     end
 
     if defined?(JRUBY_VERSION)
@@ -44,7 +44,7 @@ class PushPackage
     end
 
     if intermediate_cert
-      intermediate_cert_data = File.read(intermediate_cert)
+      intermediate_cert_data = File.binread(intermediate_cert)
       @extra_certs = [OpenSSL::X509::Certificate.new(intermediate_cert_data)]
     end
   end


### PR DESCRIPTION
When trying to create the pushPackage.zip in windows, due to the certificate being read as text, an error is thrown when creating an actual PKCS12 Certificate.

**PKCS12_parse: mac verify failure (OpenSSL::PKCS12::PKCS12Error)**

The fix is reading the certificate file as binary.

