### PR TITLE
Using new intermediate certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ This gem provides a Ruby library and command line tool for creating a push packa
 
 You must obtain a Website Push certificate from apple which requires a iOS developer license or a Mac developer license
 
-[Starting February 2016](https://developer.apple.com/support/certificates/expiration/), you will also need a copy of the
-Apple intermediate cert ([WWDR Certificate, expiring 02/07/23](https://developer.apple.com/certificationauthority/AppleWWDRCA.cer))
+You will also need a copy of the Apple intermediate cert ([WWDRCAG4 Certificate, expiring 12/10/30](https://www.apple.com/certificateauthority/AppleWWDRCAG4.cer))
 
 ```ruby
 require 'push_package'
@@ -38,7 +37,7 @@ website_params = {
 
 iconset_path = 'path/to/iconset'
 certificate = 'path/to/certificate.p12' # or certificate_string
-intermediate_cert = 'path/to/AppleWWDRCA.cer'
+intermediate_cert = 'path/to/AppleWWDRCAG4.cer'
 package = PushPackage.new(website_params, iconset_path, certificate, 'optional cert password', intermediate_cert)
 package.save('path/to/save')
 


### PR DESCRIPTION
Attempting to create a push package with the old AppleWWDRCA.cer previously linked to in the README no longer worked for webpush certificates I created today. However, using the new AppleWWDRCAG4.cer did work. I'm guessing Apple is now signing web push certificates using that intermediate cert. Updating the README so that future users don't run into the same issues, see https://github.com/SymmetricInfinity/push_package/issues/22